### PR TITLE
Relax Jason dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 **Note that `ex_cldr_calendars` version 1.24.0 and later are supported on Elixir 1.12 and later only.**
 
+## Cldr.Calendars v2.4.4
+
+This is the changelog for Cldr Calendars v2.4.4 released on June 26th, 2026.  For older changelogs please consult the release tag on [GitHub](https://github.com/elixir-cldr/cldr_calendars/tags)
+
+### Bug Fixes
+
+* Make `:jason` an optional dependency and remove it from the Dialyzer PLT applications. This preserves compatibility for environments that still need a JSON library for `ex_cldr`, while allowing runtimes with built-in JSON support to avoid depending explicitly on Jason.
+
 ## Cldr.Calendars v2.4.3
 
 This is the changelog for Cldr Calendars v2.4.3 released on May 11th, 2026.  For older changelogs please consult the release tag on [GitHub](https://github.com/elixir-cldr/cldr_calendars/tags)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cldr.Calendar.MixProject do
   use Mix.Project
 
-  @version "2.4.3"
+  @version "2.4.4"
 
   def project do
     [
@@ -22,7 +22,7 @@ defmodule Cldr.Calendar.MixProject do
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [
-        plt_add_apps: ~w(inets jason mix ex_cldr_currencies ex_cldr_units ex_cldr_lists
+        plt_add_apps: ~w(inets mix ex_cldr_currencies ex_cldr_units ex_cldr_lists
              ex_cldr_numbers calendar_interval)a,
         flags: [
           :error_handling,
@@ -80,7 +80,7 @@ defmodule Cldr.Calendar.MixProject do
       {:ex_cldr_lists, "~> 2.10", optional: true},
       {:tz, "~> 0.9", optional: true, only: [:dev, :test]},
       {:calendar_interval, "~> 0.2", optional: true},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.21", optional: true, runtime: false},
       # {:benchee, "~> 1.0", optional: true, only: [:dev, :test]},
       {:dialyxir, "~> 1.0", optional: true, only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Recent OTP/Elixir runtimes can use built-in JSON support, so this package no longer needs to depend on Jason directly.

Jason remains optional to preserve compatibility with older OTP releases where ex_cldr still needs a JSON library.

This makes it possible to use the built-in JSON implementation when available, while still supporting older runtimes.
